### PR TITLE
refactor: tighten user types and centralize error handling

### DIFF
--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,8 +1,7 @@
-import { Router, Request, Response, NextFunction } from 'express';
-import { LogType, LogOperation, LogCategory } from '../utils/enum';
-import { createLog, formatError } from '../utils/commons';
+import { Router } from 'express';
 import { verifyToken } from '../utils/auth/verifyToken';
 import UserController from '../controller/userController';
+import { asyncHandler } from '../utils/asyncHandler';
 
 const router = Router();
 
@@ -10,114 +9,36 @@ const router = Router();
  * @route GET /search
  * @description Searches for users by partial email. Requires authentication.
  */
-router.get('/search', verifyToken, async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        await UserController.getUsersByEmail(req, res, next);
-    } catch (error) {
-        await createLog(
-            LogType.DEBUG,
-            LogOperation.SEARCH,
-            LogCategory.USER,
-            formatError(error),
-            undefined,
-            next
-        );
-    }
-});
+router.get('/search', verifyToken, asyncHandler(UserController.getUsersByEmail));
 
 /**
  * @route POST /
  * @description Creates a new user with validated input data.
  */
-router.post('/', async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        await UserController.createUser(req, res, next);
-    } catch (error) {
-        await createLog(
-            LogType.DEBUG,
-            LogOperation.CREATE,
-            LogCategory.USER,
-            formatError(error),
-            req.body?.userId,
-            next
-        );
-    }
-});
+router.post('/', asyncHandler(UserController.createUser));
 
 /**
  * @route GET /:id
  * @description Retrieves a user by ID. Requires authentication.
  */
-router.get('/:id', verifyToken, async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        await UserController.getUserById(req, res, next);
-    } catch (error) {
-        await createLog(
-            LogType.DEBUG,
-            LogOperation.SEARCH,
-            LogCategory.USER,
-            formatError(error),
-            Number(req.params.id) || undefined,
-            next
-        );
-    }
-});
+router.get('/:id', verifyToken, asyncHandler(UserController.getUserById));
 
 /**
  * @route GET /
  * @description Lists all users in the system. Requires authentication.
  */
-router.get('/', verifyToken, async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        await UserController.getUsers(req, res, next);
-    } catch (error) {
-        await createLog(
-            LogType.DEBUG,
-            LogOperation.SEARCH,
-            LogCategory.USER,
-            formatError(error),
-            undefined,
-            next
-        );
-    }
-});
+router.get('/', verifyToken, asyncHandler(UserController.getUsers));
 
 /**
  * @route PUT /:id
  * @description Updates an existing user by ID. Requires authentication.
  */
-router.put('/:id?', verifyToken, async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        await UserController.updateUser(req, res, next);
-    } catch (error) {
-        await createLog(
-            LogType.DEBUG,
-            LogOperation.UPDATE,
-            LogCategory.USER,
-            formatError(error),
-            Number(req.params.id) || undefined,
-            next
-        );
-    }
-});
+router.put('/:id?', verifyToken, asyncHandler(UserController.updateUser));
 
 /**
  * @route DELETE /:id
  * @description Deletes a user by ID. Requires authentication.
  */
-router.delete('/:id?', verifyToken, async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        await UserController.deleteUser(req, res, next);
-    } catch (error) {
-        await createLog(
-            LogType.DEBUG,
-            LogOperation.DELETE,
-            LogCategory.USER,
-            JSON.stringify(error),
-            Number(req.params.id) || undefined,
-            next
-        );
-    }
-});
+router.delete('/:id?', verifyToken, asyncHandler(UserController.deleteUser));
 
 export default router;

--- a/src/service/userService.ts
+++ b/src/service/userService.ts
@@ -4,35 +4,45 @@ import { DbService } from '../utils/database/services/dbService';
 import { findWithColumnFilters } from '../utils/database/helpers/dbHelpers';
 import { DbResponse } from '../utils/database/services/dbResponse';
 import { Resource } from '../utils/resources/resource';
+import User from '../model/user/user';
+
+/** DTO for user creation */
+export interface CreateUserDTO {
+    readonly firstName: string;
+    readonly lastName: string;
+    readonly email: string;
+    readonly password: string;
+}
+
+/** DTO for user update */
+export type UpdateUserDTO = Partial<CreateUserDTO>;
+
+/** User without sensitive fields */
+export type SanitizedUser = Omit<User, 'password'>;
 
 export class UserService extends DbService {
     constructor() {
         super(TableName.USER);
     }
 
-    /**
-     * Removes sensitive fields from the user object.
-     *
-     * @param data - Raw user object with sensitive fields.
+    /** @summary Removes sensitive fields from the user object.
+     * @param data Raw user object with sensitive fields.
      * @returns User object without the password.
      */
-    private sanitizeUser(data: any): any {
+    private sanitizeUser(data?: User | null): SanitizedUser | null | undefined {
         if (!data) return data;
         const { password, ...safeUser } = data;
         return safeUser;
     }
 
-    /**
-     * Creates a new user with a unique email and hashed password.
-     * Validates that the email is not already registered.
-     *
-     * @param data - User registration data.
+    /** @summary Creates a new user with a unique email and hashed password.
+     * @param data User registration data.
      * @returns Created user record or error if email is already in use.
      */
-    async createUser(data: { firstName: string; lastName: string; email: string; password: string }): Promise<DbResponse<any>> {
+    async createUser(data: CreateUserDTO): Promise<DbResponse<SanitizedUser>> {
         data.email = data.email.trim().toLowerCase();
 
-        const existingUsers = await this.findWithFilters<any>({
+        const existingUsers = await this.findWithFilters<User>({
             email: { operator: Operator.EQUAL, value: data.email }
         });
 
@@ -47,48 +57,45 @@ export class UserService extends DbService {
             return { success: false, error: Resource.INTERNAL_SERVER_ERROR };
         }
 
-        const created = await this.findOne(result.data.id);
+        const created = await this.findOne<User>(result.data.id);
         return {
             ...created,
             data: this.sanitizeUser(created.data)
         };
     }
 
-    /**
-     * Retrieves a list of all users in the database.
-     *
+    /** @summary Retrieves a list of all users in the database.
      * @returns List of user records.
      */
-    async getUsers(): Promise<DbResponse<any[]>> {
-        const users = await this.findMany<any>();
+    async getUsers(): Promise<DbResponse<SanitizedUser[]>> {
+        const users = await this.findMany<User>();
         return {
             ...users,
             data: users.data?.map(this.sanitizeUser)
         };
     }
 
-    /**
-     * Retrieves a user by their unique ID.
-     *
-     * @param id - ID of the user.
+    /** @summary Retrieves a user by their unique ID.
+     * @param id ID of the user.
      * @returns User record if found, or error if not.
      */
-    async getUserById(id: number): Promise<DbResponse<any>> {
-        const user = await this.findOne(id);
+    async getUserById(id: number): Promise<DbResponse<SanitizedUser>> {
+        const user = await this.findOne<User>(id);
+        if (!user.success) {
+            return { success: false, error: Resource.USER_NOT_FOUND };
+        }
         return {
             ...user,
             data: this.sanitizeUser(user.data)
         };
     }
 
-    /**
-     * Searches for users by partial email using a LIKE clause.
-     *
-     * @param emailTerm - Email search term (partial match).
+    /** @summary Searches for users by partial email using a LIKE clause.
+     * @param emailTerm Email search term (partial match).
      * @returns List of users matching the email filter.
      */
-    async getUsersByEmail(emailTerm: string): Promise<DbResponse<any[]>> {
-        const result = await findWithColumnFilters<any>(TableName.USER, {
+    async getUsersByEmail(emailTerm: string): Promise<DbResponse<SanitizedUser[]>> {
+        const result = await findWithColumnFilters<User>(TableName.USER, {
             email: { operator: Operator.LIKE, value: emailTerm }
         });
         return {
@@ -97,15 +104,13 @@ export class UserService extends DbService {
         };
     }
 
-    /**
-     * Updates a user by ID and rehashes the password if it has changed.
-     *
-     * @param id - ID of the user to update.
-     * @param data - Partial user data.
+    /** @summary Updates a user by ID and rehashes the password if it has changed.
+     * @param id ID of the user to update.
+     * @param data Partial user data.
      * @returns Updated user or error if not found.
      */
-    async updateUser(id: number, data: any): Promise<DbResponse<any>> {
-        const current = await this.findOne(id);
+    async updateUser(id: number, data: UpdateUserDTO): Promise<DbResponse<SanitizedUser>> {
+        const current = await this.findOne<User>(id);
 
         if (data.password && current.success && current.data?.password) {
             const isSamePassword = await bcrypt.compare(data.password, current.data.password);
@@ -117,18 +122,16 @@ export class UserService extends DbService {
         }
 
         await this.update(id, data);
-        const updated = await this.findOne(id);
+        const updated = await this.findOne<User>(id);
         return {
             ...updated,
             data: this.sanitizeUser(updated.data)
         };
     }
 
-    /**
-     * Deletes a user by ID after validating its existence.
-     *
-     * @param id - ID of the user to delete.
-     * @returns  Success with deleted ID, or error if user does not exist.
+    /** @summary Deletes a user by ID after validating its existence.
+     * @param id ID of the user to delete.
+     * @returns Success with deleted ID, or error if user does not exist.
      */
     async deleteUser(id: number): Promise<DbResponse<{ id: number }>> {
         const existingUser = await this.findOne(id);

--- a/src/utils/asyncHandler.ts
+++ b/src/utils/asyncHandler.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * @summary Wraps async route handlers and forwards errors to Express.
+ * @param fn Async function to wrap.
+ * @returns Express request handler with centralized error propagation.
+ */
+export function asyncHandler(
+    fn: (req: Request, res: Response, next: NextFunction) => Promise<unknown>
+): RequestHandler {
+    return (req, res, next) => {
+        Promise.resolve(fn(req, res, next)).catch(next);
+    };
+}

--- a/src/utils/enum.ts
+++ b/src/utils/enum.ts
@@ -63,6 +63,7 @@ export enum DateFormat {
 export enum HTTPStatus {
     OK = 200,
     CREATED = 201,
+    NO_CONTENT = 204,
     MOVED_PERMANENTLY = 301,
     NOT_MODIFIED = 304,
     BAD_REQUEST = 400,


### PR DESCRIPTION
## Summary
- add DTOs and sanitized typing for user service to remove any
- centralize async error handling via middleware and global error logger
- align user controller responses with proper HTTP semantics

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897f9384b0c832787589985e9f1aaa7