### PR TITLE
refactor: eliminate any return types

### DIFF
--- a/src/controller/accountController.ts
+++ b/src/controller/accountController.ts
@@ -7,8 +7,7 @@ import { Resource } from '../utils/resources/resource';
 import { LanguageCode } from '../utils/resources/resourceTypes';
 
 class AccountController {
-    /**
-     * Creates a new financial account using validated input.
+    /** @summary Creates a new financial account using validated input.
      * Logs the result and returns the created account on success.
      *
      * @param req - Express request containing account data.
@@ -39,8 +38,8 @@ class AccountController {
                 return answerAPI(req, res, HTTPStatus.BAD_REQUEST, undefined, created.error);
             }
 
-            await createLog(LogType.SUCCESS, LogOperation.CREATE, LogCategory.ACCOUNT, created.data, created.data.user_id);
-            return answerAPI(req, res, HTTPStatus.CREATED, created.data);
+            await createLog(LogType.SUCCESS, LogOperation.CREATE, LogCategory.ACCOUNT, created.data, created.data!.user_id);
+            return answerAPI(req, res, HTTPStatus.CREATED, created.data!);
         } catch (error) {
             await createLog(LogType.ERROR, LogOperation.CREATE, LogCategory.ACCOUNT, formatError(error), undefined, next);
             return answerAPI(req, res, HTTPStatus.INTERNAL_SERVER_ERROR, undefined, Resource.INTERNAL_SERVER_ERROR);
@@ -136,8 +135,7 @@ class AccountController {
         }
     }
 
-    /**
-     * Updates an existing account by ID using validated input.
+    /** @summary Updates an existing account by ID using validated input.
      * Ensures account exists before updating and logs the operation.
      *
      * @param req - Express request with account ID and updated data.
@@ -170,8 +168,8 @@ class AccountController {
                 return answerAPI(req, res, HTTPStatus.BAD_REQUEST, undefined, updated.error);
             }
 
-            await createLog(LogType.SUCCESS, LogOperation.UPDATE, LogCategory.ACCOUNT, updated.data, updated.data.user_id);
-            return answerAPI(req, res, HTTPStatus.OK, updated.data);
+            await createLog(LogType.SUCCESS, LogOperation.UPDATE, LogCategory.ACCOUNT, updated.data, updated.data!.user_id);
+            return answerAPI(req, res, HTTPStatus.OK, updated.data!);
         } catch (error) {
             await createLog(LogType.ERROR, LogOperation.UPDATE, LogCategory.ACCOUNT, formatError(error), id, next);
             return answerAPI(req, res, HTTPStatus.INTERNAL_SERVER_ERROR, undefined, Resource.INTERNAL_SERVER_ERROR);

--- a/src/controller/categoryController.ts
+++ b/src/controller/categoryController.ts
@@ -7,8 +7,7 @@ import { Resource } from '../utils/resources/resource';
 import { LanguageCode } from '../utils/resources/resourceTypes';
 
 class CategoryController {
-    /**
-     * Creates a new category using validated input from the request body.
+    /** @summary Creates a new category using validated input from the request body.
      * Logs the result and returns the created category on success.
      *
      * @param req - Express request containing category data.
@@ -32,8 +31,8 @@ class CategoryController {
                 return answerAPI(req, res, HTTPStatus.BAD_REQUEST, undefined, created.error);
             }
 
-            await createLog(LogType.SUCCESS, LogOperation.CREATE, LogCategory.CATEGORY, created.data, created.data.user_id);
-            return answerAPI(req, res, HTTPStatus.CREATED, created.data);
+            await createLog(LogType.SUCCESS, LogOperation.CREATE, LogCategory.CATEGORY, created.data, created.data!.user_id);
+            return answerAPI(req, res, HTTPStatus.CREATED, created.data!);
         } catch (error) {
             await createLog(LogType.ERROR, LogOperation.CREATE, LogCategory.CATEGORY, formatError(error), undefined, next);
             return answerAPI(req, res, HTTPStatus.INTERNAL_SERVER_ERROR, undefined, Resource.INTERNAL_SERVER_ERROR);
@@ -116,8 +115,7 @@ class CategoryController {
         }
     }
 
-    /**
-     * Updates an existing category by ID.
+    /** @summary Updates an existing category by ID.
      * Validates the input and ensures the category exists.
      *
      * @param req - Express request with category ID and update data.
@@ -149,8 +147,8 @@ class CategoryController {
                 return answerAPI(req, res, HTTPStatus.BAD_REQUEST, undefined, updated.error);
             }
 
-            await createLog(LogType.SUCCESS, LogOperation.UPDATE, LogCategory.CATEGORY, updated.data, updated.data.user_id);
-            return answerAPI(req, res, HTTPStatus.OK, updated.data);
+            await createLog(LogType.SUCCESS, LogOperation.UPDATE, LogCategory.CATEGORY, updated.data, updated.data!.user_id);
+            return answerAPI(req, res, HTTPStatus.OK, updated.data!);
         } catch (error) {
             await createLog(LogType.ERROR, LogOperation.UPDATE, LogCategory.CATEGORY, formatError(error), id, next);
             return answerAPI(req, res, HTTPStatus.INTERNAL_SERVER_ERROR, undefined, Resource.INTERNAL_SERVER_ERROR);

--- a/src/controller/subcategoryController.ts
+++ b/src/controller/subcategoryController.ts
@@ -7,8 +7,7 @@ import { Resource } from '../utils/resources/resource';
 import { LanguageCode } from '../utils/resources/resourceTypes';
 
 class SubcategoryController {
-    /**
-     * Creates a new subcategory using validated input from the request body.
+    /** @summary Creates a new subcategory using validated input from the request body.
      * Validates the category before proceeding and logs the result.
      *
      * @param req - Express request containing new subcategory data.
@@ -32,8 +31,8 @@ class SubcategoryController {
                 return answerAPI(req, res, HTTPStatus.BAD_REQUEST, undefined, created.error);
             }
 
-            await createLog(LogType.SUCCESS, LogOperation.CREATE, LogCategory.CATEGORY, created.data, created.data.category_id);
-            return answerAPI(req, res, HTTPStatus.CREATED, created.data);
+            await createLog(LogType.SUCCESS, LogOperation.CREATE, LogCategory.CATEGORY, created.data, created.data!.category_id);
+            return answerAPI(req, res, HTTPStatus.CREATED, created.data!);
         } catch (error) {
             await createLog(LogType.ERROR, LogOperation.CREATE, LogCategory.CATEGORY, formatError(error), undefined, next);
             return answerAPI(req, res, HTTPStatus.INTERNAL_SERVER_ERROR, undefined, Resource.INTERNAL_SERVER_ERROR);
@@ -143,8 +142,7 @@ class SubcategoryController {
         }
     }
 
-    /**
-     * Updates an existing subcategory by ID.
+    /** @summary Updates an existing subcategory by ID.
      * Validates input and logs the result.
      *
      * @param req - Express request with subcategory ID and data.
@@ -178,8 +176,8 @@ class SubcategoryController {
                 return answerAPI(req, res, HTTPStatus.BAD_REQUEST, undefined, updated.error);
             }
 
-            await createLog(LogType.SUCCESS, LogOperation.UPDATE, LogCategory.CATEGORY, updated.data, updated.data.category_id);
-            return answerAPI(req, res, HTTPStatus.OK, updated.data);
+            await createLog(LogType.SUCCESS, LogOperation.UPDATE, LogCategory.CATEGORY, updated.data, updated.data!.category_id);
+            return answerAPI(req, res, HTTPStatus.OK, updated.data!);
         } catch (error) {
             await createLog(LogType.ERROR, LogOperation.UPDATE, LogCategory.CATEGORY, formatError(error), id, next);
             return answerAPI(req, res, HTTPStatus.INTERNAL_SERVER_ERROR, undefined, Resource.INTERNAL_SERVER_ERROR);

--- a/src/controller/transactionController.ts
+++ b/src/controller/transactionController.ts
@@ -9,8 +9,7 @@ import { LanguageCode } from '../utils/resources/resourceTypes';
 // #endregion Imports
 
 class TransactionController {
-    /**
-     * Creates a new transaction using validated input from the request body.
+    /** @summary Creates a new transaction using validated input from the request body.
      * Logs the result and returns the created transaction on success.
      *
      * @param req - Express request containing new transaction data.
@@ -41,8 +40,8 @@ class TransactionController {
                 return answerAPI(req, res, HTTPStatus.BAD_REQUEST, undefined, created.error);
             }
 
-            await createLog(LogType.SUCCESS, LogOperation.CREATE, LogCategory.TRANSACTION, created.data, created.data.account_id);
-            return answerAPI(req, res, HTTPStatus.CREATED, created.data);
+            await createLog(LogType.SUCCESS, LogOperation.CREATE, LogCategory.TRANSACTION, created.data, created.data!.account_id);
+            return answerAPI(req, res, HTTPStatus.CREATED, created.data!);
         } catch (error) {
             await createLog(LogType.ERROR, LogOperation.CREATE, LogCategory.TRANSACTION, formatError(error), undefined, next);
             return answerAPI(req, res, HTTPStatus.INTERNAL_SERVER_ERROR, undefined, Resource.INTERNAL_SERVER_ERROR);
@@ -153,8 +152,7 @@ class TransactionController {
         }
     }
 
-    /**
-     * Updates an existing transaction by ID using validated input.
+    /** @summary Updates an existing transaction by ID using validated input.
      * Ensures transaction exists before updating and logs the operation.
      *
      * @param req - Express request with transaction ID and updated data.
@@ -187,8 +185,8 @@ class TransactionController {
                 return answerAPI(req, res, HTTPStatus.BAD_REQUEST, undefined, updated.error);
             }
 
-            await createLog(LogType.SUCCESS, LogOperation.UPDATE, LogCategory.TRANSACTION, updated.data, updated.data.account_id);
-            return answerAPI(req, res, HTTPStatus.OK, updated.data);
+            await createLog(LogType.SUCCESS, LogOperation.UPDATE, LogCategory.TRANSACTION, updated.data, updated.data!.account_id);
+            return answerAPI(req, res, HTTPStatus.OK, updated.data!);
         } catch (error) {
             await createLog(LogType.ERROR, LogOperation.UPDATE, LogCategory.TRANSACTION, formatError(error), id, next);
             return answerAPI(req, res, HTTPStatus.INTERNAL_SERVER_ERROR, undefined, Resource.INTERNAL_SERVER_ERROR);

--- a/src/controller/userController.ts
+++ b/src/controller/userController.ts
@@ -8,8 +8,7 @@ import { LanguageCode } from '../utils/resources/resourceTypes';
 
 
 class UserController {
-    /**
-     * Creates a new user using validated input from the request body.
+    /** @summary Creates a new user using validated input from the request body.
      * Logs the result and returns the created user on success.
      *
      * @param req - Express request containing new user data.
@@ -40,8 +39,8 @@ class UserController {
                 return answerAPI(req, res, HTTPStatus.BAD_REQUEST, undefined, newUser.error);
             }
 
-            await createLog(LogType.SUCCESS, LogOperation.CREATE, LogCategory.USER, newUser.data, newUser.data.id);
-            return answerAPI(req, res, HTTPStatus.CREATED, newUser.data);
+            await createLog(LogType.SUCCESS, LogOperation.CREATE, LogCategory.USER, newUser.data, newUser.data!.id);
+            return answerAPI(req, res, HTTPStatus.CREATED, newUser.data!);
         } catch (error) {
             await createLog(
                 LogType.ERROR,
@@ -132,8 +131,7 @@ class UserController {
         }
     }
 
-    /**
-     * Updates an existing user by ID using validated input.
+    /** @summary Updates an existing user by ID using validated input.
      * Ensures user exists before updating and logs the result.
      *
      * @param req - Express request with user ID and updated data.
@@ -167,8 +165,8 @@ class UserController {
                 return answerAPI(req, res, HTTPStatus.BAD_REQUEST, undefined, updatedUser.error);
             }
 
-            await createLog(LogType.SUCCESS, LogOperation.UPDATE, LogCategory.USER, updatedUser.data, updatedUser.data.id);
-            return answerAPI(req, res, HTTPStatus.OK, updatedUser.data);
+            await createLog(LogType.SUCCESS, LogOperation.UPDATE, LogCategory.USER, updatedUser.data, updatedUser.data!.id);
+            return answerAPI(req, res, HTTPStatus.OK, updatedUser.data!);
         } catch (error) {
             await createLog(LogType.ERROR, LogOperation.UPDATE, LogCategory.USER, formatError(error), userId, next);
             return answerAPI(req, res, HTTPStatus.INTERNAL_SERVER_ERROR, undefined, Resource.INTERNAL_SERVER_ERROR);

--- a/src/service/accountService.ts
+++ b/src/service/accountService.ts
@@ -4,14 +4,16 @@ import { DbResponse } from '../utils/database/services/dbResponse';
 import { Resource } from '../utils/resources/resource';
 import { findWithColumnFilters } from '../utils/database/helpers/dbHelpers';
 import { UserService } from './userService';
+import Account from '../model/account/account';
+
+type AccountRow = Account & { user_id: number };
 
 export class AccountService extends DbService {
     constructor() {
         super(TableName.ACCOUNT);
     }
 
-    /**
-     * Creates a new financial account.
+    /** @summary Creates a new financial account.
      * Ensures the required data is present and linked to a valid user.
      *
      * @param data - Account creation data.
@@ -24,7 +26,7 @@ export class AccountService extends DbService {
         observation?: string;
         user_id: number;
         active?: boolean;
-    }): Promise<DbResponse<any>> {
+    }): Promise<DbResponse<AccountRow>> {
         const userService = new UserService();
         const user = await userService.getUserById(data.user_id);
 
@@ -32,54 +34,50 @@ export class AccountService extends DbService {
             return { success: false, error: Resource.USER_NOT_FOUND };
         }
 
-        const result = await this.create(data);
+        const result = await this.create<AccountRow>(data);
         if (!result.success || !result.data?.id) {
             return { success: false, error: Resource.INTERNAL_SERVER_ERROR };
         }
 
-        return this.findOne(result.data.id);
+        return this.findOne<AccountRow>(result.data.id);
     }
 
-    /**
-     * Retrieves all financial accounts from the database.
+    /** @summary Retrieves all financial accounts from the database.
      *
      * @returns A list of all account records.
      */
-    async getAccounts(): Promise<DbResponse<any[]>> {
-        return this.findMany<any>();
+    async getAccounts(): Promise<DbResponse<AccountRow[]>> {
+        return this.findMany<AccountRow>();
     }
 
-    /**
-     * Retrieves a single account by its ID.
+    /** @summary Retrieves a single account by its ID.
      *
      * @param id - ID of the account.
      * @returns Account record if found.
      */
-    async getAccountById(id: number): Promise<DbResponse<any>> {
-        return this.findOne(id);
+    async getAccountById(id: number): Promise<DbResponse<AccountRow>> {
+        return this.findOne<AccountRow>(id);
     }
 
-    /**
-     * Retrieves all accounts associated with a given user ID.
+    /** @summary Retrieves all accounts associated with a given user ID.
      *
      * @param userId - ID of the user.
      * @returns A list of accounts owned by the user.
      */
-    async getAccountsByUser(userId: number): Promise<DbResponse<any[]>> {
-        return findWithColumnFilters<any>(TableName.ACCOUNT, {
+    async getAccountsByUser(userId: number): Promise<DbResponse<AccountRow[]>> {
+        return findWithColumnFilters<AccountRow>(TableName.ACCOUNT, {
             user_id: { operator: Operator.EQUAL, value: userId }
         });
     }
 
-    /**
-     * Updates an account by ID.
+    /** @summary Updates an account by ID.
      * Validates the user if the user_id is being changed.
      *
      * @param id - ID of the account.
      * @param data - Partial account data to update.
      * @returns Updated account record.
      */
-    async updateAccount(id: number, data: Partial<any>): Promise<DbResponse<any>> {
+    async updateAccount(id: number, data: Partial<AccountRow>): Promise<DbResponse<AccountRow>> {
         if (data.user_id !== undefined) {
             const userService = new UserService();
             const user = await userService.getUserById(data.user_id);
@@ -89,12 +87,12 @@ export class AccountService extends DbService {
             }
         }
 
-        const updateResult = await this.update(id, data);
+        const updateResult = await this.update<AccountRow>(id, data);
         if (!updateResult.success) {
             return { success: false, error: Resource.INTERNAL_SERVER_ERROR };
         }
 
-        return this.findOne(id);
+        return this.findOne<AccountRow>(id);
     }
 
     /**
@@ -104,7 +102,7 @@ export class AccountService extends DbService {
      * @returns Success with deleted ID, or error if account does not exist.
      */
     async deleteAccount(id: number): Promise<DbResponse<{ id: number }>> {
-        const existing = await this.findOne(id);
+        const existing = await this.findOne<AccountRow>(id);
 
         if (!existing.success) {
             return { success: false, error: Resource.ACCOUNT_NOT_FOUND };

--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -8,6 +8,8 @@ import User from '../model/user/user';
 import { RefreshTokenService } from './refreshTokenService';
 import { UserService } from './userService';
 import RefreshToken from '../model/refresh_token/refresh_token';
+
+type RefreshTokenRow = RefreshToken & { user_id: number };
 import { createLog } from '../utils/commons';
 
 export class AuthService {
@@ -52,7 +54,7 @@ export class AuthService {
         const expiresAt = new Date();
         expiresAt.setFullYear(expiresAt.getFullYear() + 1);
 
-        await this.tokenDb.create({
+        await this.tokenDb.create<RefreshTokenRow>({
             token: refreshToken,
             user_id: user.id,
             expiresAt
@@ -104,7 +106,7 @@ export class AuthService {
      * @returns Success status and user ID if logout succeeds, or error if token is not found.
      */
     async logout(token: string): Promise<DbResponse<{ userId: number }>> {
-        const tokens = await this.tokenDb.findMany({ token });
+        const tokens = await this.tokenDb.findMany<RefreshTokenRow>({ token });
         const stored = tokens.data?.[0];
 
         if (!stored) {

--- a/src/service/categoryService.ts
+++ b/src/service/categoryService.ts
@@ -4,14 +4,16 @@ import { DbResponse } from '../utils/database/services/dbResponse';
 import { Resource } from '../utils/resources/resource';
 import { findWithColumnFilters } from '../utils/database/helpers/dbHelpers';
 import { UserService } from './userService';
+import Category from '../model/category/category';
+
+type CategoryRow = Category & { user_id: number };
 
 export class CategoryService extends DbService {
     constructor() {
         super(TableName.CATEGORY);
     }
 
-    /**
-     * Creates a new category linked to a valid user.
+    /** @summary Creates a new category linked to a valid user.
      *
      * @param data - Category creation data.
      * @returns The created category record.
@@ -22,7 +24,7 @@ export class CategoryService extends DbService {
         color?: string;
         active?: boolean;
         user_id: number;
-    }): Promise<DbResponse<any>> {
+    }): Promise<DbResponse<CategoryRow>> {
         const userService = new UserService();
         const user = await userService.getUserById(data.user_id);
 
@@ -30,55 +32,51 @@ export class CategoryService extends DbService {
             return { success: false, error: Resource.USER_NOT_FOUND };
         }
 
-        const result = await this.create(data);
+        const result = await this.create<CategoryRow>(data);
         if (!result.success || !result.data?.id) {
             return { success: false, error: Resource.INTERNAL_SERVER_ERROR };
         }
 
-        return this.findOne(result.data.id);
+        return this.findOne<CategoryRow>(result.data.id);
     }
 
 
-    /**
-     * Retrieves all category records from the database.
+    /** @summary Retrieves all category records from the database.
      *
      * @returns A list of all categories.
      */
-    async getCategories(): Promise<DbResponse<any[]>> {
-        return this.findMany<any>();
+    async getCategories(): Promise<DbResponse<CategoryRow[]>> {
+        return this.findMany<CategoryRow>();
     }
 
-    /**
-     * Retrieves a category by its ID.
+    /** @summary Retrieves a category by its ID.
      *
      * @param id - ID of the category.
      * @returns The category if found.
      */
-    async getCategoryById(id: number): Promise<DbResponse<any>> {
-        return this.findOne(id);
+    async getCategoryById(id: number): Promise<DbResponse<CategoryRow>> {
+        return this.findOne<CategoryRow>(id);
     }
 
-    /**
-     * Retrieves all categories linked to a specific user.
+    /** @summary Retrieves all categories linked to a specific user.
      *
      * @param userId - ID of the user.
      * @returns A list of categories owned by the user.
      */
-    async getCategoriesByUser(userId: number): Promise<DbResponse<any[]>> {
-        return findWithColumnFilters<any>(TableName.CATEGORY, {
+    async getCategoriesByUser(userId: number): Promise<DbResponse<CategoryRow[]>> {
+        return findWithColumnFilters<CategoryRow>(TableName.CATEGORY, {
             user_id: { operator: Operator.EQUAL, value: userId }
         });
     }
 
-    /**
-     * Updates a category by ID.
+    /** @summary Updates a category by ID.
      * Validates the user if the user_id is being changed.
      *
      * @param id - ID of the category.
      * @param data - Partial category data to update.
      * @returns Updated category record.
      */
-    async updateCategory(id: number, data: Partial<any>): Promise<DbResponse<any>> {
+    async updateCategory(id: number, data: Partial<CategoryRow>): Promise<DbResponse<CategoryRow>> {
         if (data.user_id !== undefined) {
             const userService = new UserService();
             const user = await userService.getUserById(data.user_id);
@@ -88,12 +86,12 @@ export class CategoryService extends DbService {
             }
         }
 
-        const updateResult = await this.update(id, data);
+        const updateResult = await this.update<CategoryRow>(id, data);
         if (!updateResult.success) {
             return { success: false, error: Resource.INTERNAL_SERVER_ERROR };
         }
 
-        return this.findOne(id);
+        return this.findOne<CategoryRow>(id);
     }
 
     /**
@@ -103,7 +101,7 @@ export class CategoryService extends DbService {
      * @returns  Success with deleted ID, or error if category does not exist.
      */
     async deleteCategory(id: number): Promise<DbResponse<{ id: number }>> {
-        const existing = await this.findOne(id);
+        const existing = await this.findOne<CategoryRow>(id);
 
         if (!existing.success) {
             return { success: false, error: Resource.CATEGORY_NOT_FOUND };

--- a/src/service/logService.ts
+++ b/src/service/logService.ts
@@ -4,6 +4,9 @@ import { DbResponse } from '../utils/database/services/dbResponse';
 import { insert, removeOlderThan } from '../utils/database/helpers/dbHelpers';
 import { createLog } from '../utils/commons';
 import { Resource } from '../utils/resources/resource';
+import Log from '../model/log/log';
+
+type LogRow = Log & { user_id: number | null };
 
 interface LogData {
     type: LogType;
@@ -96,19 +99,18 @@ export class LogService extends DbService {
         return result;
     }
 
-    /**
-     * Retrieves all logs associated with a given user ID.
+    /** @summary Retrieves all logs associated with a given user ID.
      * Validates the input before executing the query.
      *
      * @param user_id - User ID to filter logs by.
      * @returns Array of logs or error if ID is invalid.
      */
-    async getLogsByUser(user_id: number | null): Promise<DbResponse<any[]>> {
+    async getLogsByUser(user_id: number | null): Promise<DbResponse<LogRow[]>> {
         if (user_id === null || isNaN(user_id) || user_id <= 0) {
             return { success: false, error: Resource.INVALID_USER_ID };
         }
 
-        return this.findWithFilters(
+        return this.findWithFilters<LogRow>(
             {
                 user_id: { operator: Operator.EQUAL, value: user_id }
             });

--- a/src/service/subcategoryService.ts
+++ b/src/service/subcategoryService.ts
@@ -4,14 +4,16 @@ import { DbResponse } from '../utils/database/services/dbResponse';
 import { Resource } from '../utils/resources/resource';
 import { findWithColumnFilters } from '../utils/database/helpers/dbHelpers';
 import { CategoryService } from './categoryService';
+import Subcategory from '../model/subcategory/subcategory';
+
+type SubcategoryRow = Subcategory & { category_id: number };
 
 export class SubcategoryService extends DbService {
     constructor() {
         super(TableName.SUBCATEGORY);
     }
 
-    /**
-     * Creates a new subcategory.
+    /** @summary Creates a new subcategory.
      * Ensures the required data is present and linked to a valid and authorized category.
      *
      * @param data - Subcategory creation data.
@@ -22,7 +24,7 @@ export class SubcategoryService extends DbService {
         name: string;
         category_id: number;
         active?: boolean;
-    }, userId?: number): Promise<DbResponse<any>> {
+    }, userId?: number): Promise<DbResponse<SubcategoryRow>> {
         const categoryService = new CategoryService();
         const category = await categoryService.getCategoryById(data.category_id);
 
@@ -34,55 +36,51 @@ export class SubcategoryService extends DbService {
             return { success: false, error: Resource.UNAUTHORIZED_OPERATION };
         }
 
-        const result = await this.create(data);
+        const result = await this.create<SubcategoryRow>(data);
         if (!result.success || !result.data?.id) {
             return { success: false, error: Resource.INTERNAL_SERVER_ERROR };
         }
 
-        return this.findOne(result.data.id);
+        return this.findOne<SubcategoryRow>(result.data.id);
     }
 
 
 
-    /**
-     * Retrieves all subcategories from the database.
+    /** @summary Retrieves all subcategories from the database.
      *
      * @returns A list of all subcategories.
      */
-    async getSubcategories(): Promise<DbResponse<any[]>> {
-        return this.findMany<any>();
+    async getSubcategories(): Promise<DbResponse<SubcategoryRow[]>> {
+        return this.findMany<SubcategoryRow>();
     }
 
-    /**
-     * Retrieves all subcategories for a given category ID.
+    /** @summary Retrieves all subcategories for a given category ID.
      *
      * @param categoryId - ID of the parent category.
      * @returns A list of subcategories under the specified category.
      */
-    async getSubcategoriesByCategory(categoryId: number): Promise<DbResponse<any[]>> {
-        return findWithColumnFilters<any>(TableName.SUBCATEGORY, {
+    async getSubcategoriesByCategory(categoryId: number): Promise<DbResponse<SubcategoryRow[]>> {
+        return findWithColumnFilters<SubcategoryRow>(TableName.SUBCATEGORY, {
             category_id: { operator: Operator.EQUAL, value: categoryId }
         });
     }
 
-    /**
-     * Retrieves a subcategory by its ID.
+    /** @summary Retrieves a subcategory by its ID.
      *
      * @param id - ID of the subcategory.
      * @returns Subcategory record if found.
      */
-    async getSubcategoryById(id: number): Promise<DbResponse<any>> {
-        return this.findOne(id);
+    async getSubcategoryById(id: number): Promise<DbResponse<SubcategoryRow>> {
+        return this.findOne<SubcategoryRow>(id);
     }
 
 
-    /**
-     * Retrieves all subcategories linked to any category of a specific user.
+    /** @summary Retrieves all subcategories linked to any category of a specific user.
      *
      * @param userId - ID of the user whose subcategories are being requested.
      * @returns A list of subcategories across all categories owned by the user.
      */
-    async getSubcategoriesByUser(userId: number): Promise<DbResponse<any[]>> {
+    async getSubcategoriesByUser(userId: number): Promise<DbResponse<SubcategoryRow[]>> {
         const categoryService = new CategoryService();
         const userCategories = await categoryService.getCategoriesByUser(userId);
 
@@ -92,14 +90,13 @@ export class SubcategoryService extends DbService {
 
         const categoryIds = userCategories.data.map(c => c.id);
 
-        return findWithColumnFilters<any>(TableName.SUBCATEGORY, {
+        return findWithColumnFilters<SubcategoryRow>(TableName.SUBCATEGORY, {
             category_id: { operator: Operator.IN, value: categoryIds }
         });
     }
 
 
-    /**
-     * Updates a subcategory by ID.
+    /** @summary Updates a subcategory by ID.
      * Validates the category if the category_id is being changed, including ownership.
      *
      * @param id - ID of the subcategory.
@@ -107,7 +104,7 @@ export class SubcategoryService extends DbService {
      * @param userId - Optional ID of the user performing the operation.
      * @returns Updated subcategory record.
      */
-    async updateSubcategory(id: number, data: Partial<any>, userId?: number): Promise<DbResponse<any>> {
+    async updateSubcategory(id: number, data: Partial<SubcategoryRow>, userId?: number): Promise<DbResponse<SubcategoryRow>> {
         if (data.category_id !== undefined) {
             const categoryService = new CategoryService();
             const category = await categoryService.getCategoryById(data.category_id);
@@ -121,11 +118,11 @@ export class SubcategoryService extends DbService {
             }
         }
 
-        const updateResult = await this.update(id, data);
+        const updateResult = await this.update<SubcategoryRow>(id, data);
         if (!updateResult.success) {
             return { success: false, error: Resource.INTERNAL_SERVER_ERROR };
         }
-        return this.findOne(id);
+        return this.findOne<SubcategoryRow>(id);
     }
 
 
@@ -136,7 +133,7 @@ export class SubcategoryService extends DbService {
      * @returns  Success with deleted ID, or error if subcategory does not exist.
      */
     async deleteSubcategory(id: number): Promise<DbResponse<{ id: number }>> {
-        const existing = await this.findOne(id);
+        const existing = await this.findOne<SubcategoryRow>(id);
 
         if (!existing.success) {
             return { success: false, error: Resource.SUBCATEGORY_NOT_FOUND };

--- a/src/service/userService.ts
+++ b/src/service/userService.ts
@@ -4,35 +4,35 @@ import { DbService } from '../utils/database/services/dbService';
 import { findWithColumnFilters } from '../utils/database/helpers/dbHelpers';
 import { DbResponse } from '../utils/database/services/dbResponse';
 import { Resource } from '../utils/resources/resource';
+import User from '../model/user/user';
+
+export type SanitizedUser = Omit<User, 'password'>;
 
 export class UserService extends DbService {
     constructor() {
         super(TableName.USER);
     }
 
-    /**
-     * Removes sensitive fields from the user object.
+    /** @summary Removes sensitive fields from the user object.
      *
      * @param data - Raw user object with sensitive fields.
      * @returns User object without the password.
      */
-    private sanitizeUser(data: any): any {
-        if (!data) return data;
+    private sanitizeUser(data: User): SanitizedUser {
         const { password, ...safeUser } = data;
         return safeUser;
     }
 
-    /**
-     * Creates a new user with a unique email and hashed password.
+    /** @summary Creates a new user with a unique email and hashed password.
      * Validates that the email is not already registered.
      *
      * @param data - User registration data.
      * @returns Created user record or error if email is already in use.
      */
-    async createUser(data: { firstName: string; lastName: string; email: string; password: string }): Promise<DbResponse<any>> {
+    async createUser(data: { firstName: string; lastName: string; email: string; password: string }): Promise<DbResponse<SanitizedUser>> {
         data.email = data.email.trim().toLowerCase();
 
-        const existingUsers = await this.findWithFilters<any>({
+        const existingUsers = await this.findWithFilters<User>({
             email: { operator: Operator.EQUAL, value: data.email }
         });
 
@@ -41,71 +41,67 @@ export class UserService extends DbService {
         }
 
         data.password = await bcrypt.hash(data.password, 10);
-        const result = await this.create(data);
+        const result = await this.create<User>(data);
 
         if (!result.success || !result.data?.id) {
             return { success: false, error: Resource.INTERNAL_SERVER_ERROR };
         }
 
-        const created = await this.findOne(result.data.id);
+        const created = await this.findOne<User>(result.data.id);
         return {
             ...created,
-            data: this.sanitizeUser(created.data)
+            data: created.data ? this.sanitizeUser(created.data) : undefined
         };
     }
 
-    /**
-     * Retrieves a list of all users in the database.
+    /** @summary Retrieves a list of all users in the database.
      *
      * @returns List of user records.
      */
-    async getUsers(): Promise<DbResponse<any[]>> {
-        const users = await this.findMany<any>();
+    async getUsers(): Promise<DbResponse<SanitizedUser[]>> {
+        const users = await this.findMany<User>();
         return {
             ...users,
-            data: users.data?.map(this.sanitizeUser)
+            data: users.data?.map(u => this.sanitizeUser(u))
         };
     }
 
-    /**
-     * Retrieves a user by their unique ID.
+    /** @summary Retrieves a user by their unique ID.
      *
      * @param id - ID of the user.
      * @returns User record if found, or error if not.
      */
-    async getUserById(id: number): Promise<DbResponse<any>> {
-        const user = await this.findOne(id);
+    async getUserById(id: number): Promise<DbResponse<SanitizedUser>> {
+        const user = await this.findOne<User>(id);
         return {
             ...user,
-            data: this.sanitizeUser(user.data)
+            data: user.data ? this.sanitizeUser(user.data) : undefined
         };
     }
 
-    /**
-     * Searches for users by partial email using a LIKE clause.
+    /** @summary Searches for users by partial email using a LIKE clause.
      *
      * @param emailTerm - Email search term (partial match).
      * @returns List of users matching the email filter.
      */
-    async getUsersByEmail(emailTerm: string): Promise<DbResponse<any[]>> {
-        const result = await findWithColumnFilters<any>(TableName.USER, {
+    async getUsersByEmail(emailTerm: string): Promise<DbResponse<SanitizedUser[]>> {
+        const result = await findWithColumnFilters<User>(TableName.USER, {
             email: { operator: Operator.LIKE, value: emailTerm }
         });
         return {
             ...result,
-            data: result.data?.map(this.sanitizeUser)
+            data: result.data?.map(u => this.sanitizeUser(u))
         };
     }
 
-    /**
-     * Updates a user by ID and rehashes the password if it has changed.
+    /** @summary Updates a user by ID and rehashes the password if it has changed.
      *
      * @param id - ID of the user to update.
      * @param data - Partial user data.
      * @returns Updated user or error if not found.
      */
-    async updateUser(id: number, data: any): Promise<DbResponse<any>> {
-        const current = await this.findOne(id);
+    async updateUser(id: number, data: Partial<User>): Promise<DbResponse<SanitizedUser>> {
+        const current = await this.findOne<User>(id);
 
         if (data.password && current.success && current.data?.password) {
             const isSamePassword = await bcrypt.compare(data.password, current.data.password);
@@ -116,11 +112,11 @@ export class UserService extends DbService {
             }
         }
 
-        await this.update(id, data);
-        const updated = await this.findOne(id);
+        await this.update<User>(id, data);
+        const updated = await this.findOne<User>(id);
         return {
             ...updated,
-            data: this.sanitizeUser(updated.data)
+            data: updated.data ? this.sanitizeUser(updated.data) : undefined
         };
     }
 
@@ -131,7 +127,7 @@ export class UserService extends DbService {
      * @returns  Success with deleted ID, or error if user does not exist.
      */
     async deleteUser(id: number): Promise<DbResponse<{ id: number }>> {
-        const existingUser = await this.findOne(id);
+        const existingUser = await this.findOne<User>(id);
 
         if (!existingUser.success) {
             return { success: false, error: Resource.USER_NOT_FOUND };

--- a/src/utils/commons.ts
+++ b/src/utils/commons.ts
@@ -140,10 +140,15 @@ export function answerAPI(
  * @param error - Unknown error object.
  * @returns A structured object with message, name and stack trace (if applicable).
  */
-export function formatError(error: unknown): Record<string, any> {
+export function formatError(error: unknown): Record<string, unknown> {
     if (error instanceof Error) {
 
-        const detailedError = error as any;
+        const detailedError = (error as unknown) as Record<string, unknown> & {
+            sqlMessage?: string;
+            code?: string;
+            errno?: number;
+            sqlState?: string;
+        };
         const message =
             error.message ||
             detailedError.sqlMessage ||
@@ -159,7 +164,7 @@ export function formatError(error: unknown): Record<string, any> {
     }
 
     if (typeof error === 'object' && error !== null) {
-        return error as Record<string, any>;
+        return error as Record<string, unknown>;
     }
 
     return { message: error };

--- a/src/utils/database/schemas/dbModels.ts
+++ b/src/utils/database/schemas/dbModels.ts
@@ -11,7 +11,9 @@ import { LogType, LogOperation, LogCategory } from "../../enum";
  * @param dir - Optional directory path (defaults to /model).
  * @returns Array of loaded model classes.
  */
-export function getModels(dir = path.resolve(__dirname, "../../../model/")) {
+type ModelClass = { tableName: string };
+
+export function getModels(dir = path.resolve(__dirname, "../../../model/")): ModelClass[] {
     if (!fs.existsSync(dir)) {
         createLog
             (LogType.ERROR,
@@ -23,7 +25,7 @@ export function getModels(dir = path.resolve(__dirname, "../../../model/")) {
         return [];
     }
 
-    let models: any[] = [];
+    let models: ModelClass[] = [];
     const files = fs.readdirSync(dir);
 
     for (const file of files) {
@@ -39,7 +41,7 @@ export function getModels(dir = path.resolve(__dirname, "../../../model/")) {
                 LogCategory.DATABASE,
                 `Loading model: '${file}'`
             );
-            models.push(require(fullPath).default);
+            models.push(require(fullPath).default as ModelClass);
         }
     }
 

--- a/src/utils/database/services/dbService.ts
+++ b/src/utils/database/services/dbService.ts
@@ -18,7 +18,7 @@ export abstract class DbService {
      * @param id - The ID of the entry to retrieve.
      * @returns The found entry or an error if not found.
      */
-    async findOne<T = any>(id: number): Promise<DbResponse<T>> {
+    async findOne<T>(id: number): Promise<DbResponse<T>> {
         return findById<T>(this.table, id);
     }
 
@@ -27,7 +27,7 @@ export abstract class DbService {
      * @param filter - Optional criteria to filter entries.
      * @returns List of found entries.
      */
-    async findMany<T = any>(filter?: object): Promise<DbResponse<T[]>> {
+    async findMany<T>(filter?: object): Promise<DbResponse<T[]>> {
         return findMany<T>(this.table, filter);
     }
 
@@ -39,7 +39,7 @@ export abstract class DbService {
      * @param options - Optional ordering and pagination options.
      * @returns Matching records or an empty list.
      */
-    async findWithFilters<T = any>(
+    async findWithFilters<T>(
         filters?: {
             [K in keyof T]?:
             | { operator: Operator.EQUAL; value: T[K] }
@@ -62,7 +62,7 @@ export abstract class DbService {
      * @param data - Data to create the new entry.
      * @returns The newly created entry.
      */
-    async create<T = any>(data: object): Promise<DbResponse<T>> {
+    async create<T>(data: object): Promise<DbResponse<T>> {
         return insert<T>(this.table, data);
     }
 
@@ -72,7 +72,7 @@ export abstract class DbService {
      * @param data - Data to be updated.
      * @returns Updated entry or an error if entry not found.
      */
-    async update<T = any>(id: number, data: object): Promise<DbResponse<T>> {
+    async update<T>(id: number, data: object): Promise<DbResponse<T>> {
         const updateResult = await update(this.table, id, data);
 
         if (!updateResult.success) {


### PR DESCRIPTION
## Summary
- replace Record<string, any> with unknown in error formatter
- enforce generics in DbService and type service methods with domain models
- return sanitized user objects and typed rows for accounts, transactions, categories, logs

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6898c155f6788327a621540806ac65c0